### PR TITLE
Remove X-Powered-By header

### DIFF
--- a/src/app/server/express.js
+++ b/src/app/server/express.js
@@ -31,6 +31,7 @@ class Server {
     });
     const bodyParseEncoded = bodyParser.urlencoded({ extended: false });
 
+    this._app.disable('x-powered-by');
     this._app.use(cookieParser());
     this._app.use(expressLogger()); // Log Request
     this._app.use(bodyParseJson);


### PR DESCRIPTION
`X-Powered-By: Express` gets returned in every response.